### PR TITLE
Import requests.__init__ rather than requests

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -1,3 +1,3 @@
 bunch>=1.0.1
 simplejson>=2.4.0
-requests==1.2.0
+requests==2.7.0

--- a/src/facegraph/__init__.py
+++ b/src/facegraph/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.1.15'
+__version__ = '1.0.0'
 
 from facegraph.api import Api
 from facegraph.api import ApiException

--- a/src/facegraph/__init__.py
+++ b/src/facegraph/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.1.14'
+__version__ = '0.1.15'
 
 from facegraph.api import Api
 from facegraph.api import ApiException

--- a/src/facegraph/fql.py
+++ b/src/facegraph/fql.py
@@ -7,11 +7,12 @@ from url_operations import add_path, update_query_params
 
 import eventlet
 requests = eventlet.import_patched('requests.__init__')
+requests_adapters = eventlet.import_patched('requests.adapters')
 
 session = requests.Session()
 session.headers['Accept-encoding'] = 'gzip'
-session.mount('http://', requests.adapters.HTTPAdapter(pool_connections=500, pool_maxsize=500))
-session.mount('https://', requests.adapters.HTTPAdapter(pool_connections=500, pool_maxsize=500))
+session.mount('http://', requests_adapters.HTTPAdapter(pool_connections=500, pool_maxsize=500))
+session.mount('https://', requests_adapters.HTTPAdapter(pool_connections=500, pool_maxsize=500))
 
 class FQL(object):
     

--- a/src/facegraph/fql.py
+++ b/src/facegraph/fql.py
@@ -6,7 +6,7 @@ from graph import GraphException
 from url_operations import add_path, update_query_params
 
 import eventlet
-requests = eventlet.import_patched('requests')
+requests = eventlet.import_patched('requests.__init__')
 
 session = requests.Session()
 session.headers['Accept-encoding'] = 'gzip'

--- a/src/facegraph/graph.py
+++ b/src/facegraph/graph.py
@@ -16,7 +16,7 @@ from simplejson.decoder import JSONDecodeError
 from functools import partial
 
 import eventlet
-requests = eventlet.import_patched('requests')
+requests = eventlet.import_patched('requests.__init__')
 
 session = requests.Session()
 session.headers['Accept-encoding'] = 'gzip'

--- a/src/facegraph/graph.py
+++ b/src/facegraph/graph.py
@@ -17,11 +17,12 @@ from functools import partial
 
 import eventlet
 requests = eventlet.import_patched('requests.__init__')
+requests_adapters = eventlet.import_patched('requests.adapters')
 
 session = requests.Session()
 session.headers['Accept-encoding'] = 'gzip'
-session.mount('http://', requests.adapters.HTTPAdapter(pool_connections=500, pool_maxsize=500))
-session.mount('https://', requests.adapters.HTTPAdapter(pool_connections=500, pool_maxsize=500))
+session.mount('http://', requests_adapters.HTTPAdapter(pool_connections=500, pool_maxsize=500))
+session.mount('https://', requests_adapters.HTTPAdapter(pool_connections=500, pool_maxsize=500))
 
 p = "^\(#(\d+)\)"
 code_re = re.compile(p)


### PR DESCRIPTION
Avoids bug importing requests patched - see
https://github.com/eventlet/eventlet/issues/7
